### PR TITLE
Embed breaks back button behavior

### DIFF
--- a/packages/features/embed/lib/EmbedTabs.tsx
+++ b/packages/features/embed/lib/EmbedTabs.tsx
@@ -118,6 +118,7 @@ export const tabs = [
       { calLink: string; embedType: EmbedType; previewState: PreviewState }
     >(function Preview({ calLink, embedType }, ref) {
       const bookerUrl = useBookerUrl();
+      const iframeSrc = `${EMBED_PREVIEW_HTML_URL}?embedType=${embedType}&calLink=${calLink}&embedLibUrl=${embedLibUrl}&bookerUrl=${bookerUrl}`
       if (ref instanceof Function || !ref) {
         return null;
       }
@@ -131,7 +132,8 @@ export const tabs = [
           className="h-[100vh] border"
           width="100%"
           height="100%"
-          src={`${EMBED_PREVIEW_HTML_URL}?embedType=${embedType}&calLink=${calLink}&embedLibUrl=${embedLibUrl}&bookerUrl=${bookerUrl}`}
+          src={iframeSrc}
+          key={iframeSrc}
         />
       );
     }),


### PR DESCRIPTION
/claim #11558

## What does this PR do?
This PR fixes [#11558](https://github.com/calcom/cal.com/issues/11558)

Fixes # (issue)

- Added the dynamic src in key attribute of the iframe

## Requirement/Documentation

I've followed the [solution](https://github.com/vercel/next.js/issues/8107) provided in the issue's description

## Type of change

<!-- Please delete bullets that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

